### PR TITLE
Auto approve in dev

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    polyn-cli (0.1.3)
+    polyn-cli (0.1.4)
       dotenv (~> 2.7.6)
       json_schemer (~> 0.2)
       nats-pure (~> 2.0.0)

--- a/lib/polyn/cli.rb
+++ b/lib/polyn/cli.rb
@@ -130,7 +130,7 @@ module Polyn
 
       def tf_apply
         if polyn_env == "development"
-          %(terraform apply -var "jetstream_servers=#{nats_servers}")
+          %(terraform apply -auto-approve -input=false -var "jetstream_servers=#{nats_servers}")
         else
           "terraform apply -auto-approve -input=false "\
             "-var \"jetstream_servers=#{nats_servers}\" "\

--- a/lib/polyn/cli/version.rb
+++ b/lib/polyn/cli/version.rb
@@ -2,6 +2,6 @@
 
 module Polyn
   class Cli
-    VERSION = "0.1.3"
+    VERSION = "0.1.4"
   end
 end


### PR DESCRIPTION
The dev environment gets used to setup nats for ci test runs so we don't want pause on interaction